### PR TITLE
Don't fail on missing 'requirements.txt'

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -102,8 +102,10 @@ if __name__ == '__main__':
     candidates.sort(key=lambda i: (-len(i)))
     filename = candidates[0]
 
-    run_requires = read_from_tarball(filename, '/requirements.txt')
-
+    try:
+        run_requires = read_from_tarball(filename, '/requirements.txt')
+    except Exception:
+        run_requires = ""
     try:
         test_requires = read_from_tarball(filename, '/test-requirements.txt')
     except Exception:


### PR DESCRIPTION
Many packages include several tarballs, of which only some include
pip-style requirements.txt files. Don't choke on the other ones.
