### PR TITLE
Add discover to ignore list

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -137,6 +137,7 @@ def sanitize_requirements(requirements):
 
     # ignore some requirements
     ignore_requires = (
+        'python-discover',  # not needed since we only care about >= py27
         'python-coverage',
         'python-sphinx', 'python-setuptools_git',
         'python-setuptools',


### PR DESCRIPTION
discover is a backport from python 2.7. We no longer care for OpenStack
packages about python <2.7 so this requirement can be ignored.