### PR TITLE
Allow and ignore markers in requirements

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -95,7 +95,10 @@ def sanitize_requirements(requirements):
         l = re.sub('#.*', ' ', l)
         # strip away whitespace
         l = re.sub('[ \t]*', '', l)
-
+        # ignore for now markers (see PEP 0426 and also
+        # https://pip.pypa.io/en/latest/reference/pip_install.html#requirements-file-format
+        # TODO(toabctl): parse and use markers
+        l = l.split(";")[0]
         if not l or l.startswith("-f"):
             continue
 

--- a/tests.py
+++ b/tests.py
@@ -83,6 +83,21 @@ class SanitizeRequirementsTests(unittest.TestCase):
                          pr.sanitize_requirements(
                              "hacking>=0.10.0,<0.11\nqpid-python"))
 
+    def test_with_markers(self):
+        """ allow markers in requirement lines"""
+        self.assertEqual(
+            {"python-futures": "3.0"},
+            pr.sanitize_requirements(
+                "futures>=3.0;python_version=='2.7' or python_version=='2.6'"))
+
+    def test_with_markers_and_lowest_version(self):
+        """ allow markers in requirement lines;multiple versions specified"""
+        self.assertEqual(
+            {"python-futures": "3.0"},
+            pr.sanitize_requirements(
+                "futures>=3.0,<=4.1,!=4.0;python_version=='2.7'"
+                "or python_version=='2.6'"))
+
 
 class UpdateRequiresCompleteTest(unittest.TestCase):
     def test_empty(self):


### PR DESCRIPTION
requirements files can contain markers (see PEP 0426). Ignore them for
now so dependencies can be automatically updated.

This is a workaround to fix trackupstream for Cloud:OpenStack:Master .