### PR TITLE
Allow and ignore markers in requirements #2

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -99,7 +99,9 @@ def sanitize_requirements(requirements):
         # https://pip.pypa.io/en/latest/reference/pip_install.html#requirements-file-format
         # TODO(toabctl): parse and use markers
         l = l.split(";")[0]
-        if not l or l.startswith("-f"):
+
+        # in egg/requires.txt, there are sections starting with "[" for markers
+        if not l or l.startswith("-f") or l.startswith("["):
             continue
 
         m = re.match('^http://tarballs.openstack.org/([^/]+)/', l)

--- a/tests.py
+++ b/tests.py
@@ -98,6 +98,13 @@ class SanitizeRequirementsTests(unittest.TestCase):
                 "futures>=3.0,<=4.1,!=4.0;python_version=='2.7'"
                 "or python_version=='2.6'"))
 
+    def test_with_markers_for_egg_requires(self):
+        """ allow markers in requires.txt from eggs"""
+        self.assertEqual(
+            {"python-futures": "3.0", "python-unittest2": None},
+            pr.sanitize_requirements(
+                "futures>=3.0\n[:python_version=='2.6']\nunittest2"))
+
 
 class UpdateRequiresCompleteTest(unittest.TestCase):
     def test_empty(self):


### PR DESCRIPTION
egg-info/requires.txt files are also parsed. Ignore the marker sections
there, too. This is also just a workaround to be able to parse the
requires.txt files.