### PR TITLE
Use last modified tarball

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -171,12 +171,7 @@ def update_requires_complete(requires_complete,
     return requires_complete
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Python Requires')
-    parser.add_argument('--outdir',
-                        help='osc service parameter that does nothing')
-    args = parser.parse_args()
-
+def get_tarball_candidate():
     # Try to find the tarball
     candidates = set()
     for d in os.listdir('.'):
@@ -184,8 +179,18 @@ if __name__ == '__main__':
             candidates.add(d)
 
     candidates = list(candidates)
-    candidates.sort(key=lambda i: (-len(i)))
-    filename = candidates[0]
+    candidates.sort(key=lambda x: os.stat(
+        os.path.join(os.getcwd(), x)).st_mtime, reverse=True)
+    return candidates[0]
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Python Requires')
+    parser.add_argument('--outdir',
+                        help='osc service parameter that does nothing')
+    args = parser.parse_args()
+
+    filename = get_tarball_candidate()
 
     # dict of tuple with requirements and their source
     requires_complete = dict()

--- a/tests.py
+++ b/tests.py
@@ -20,6 +20,10 @@ try:
 except ImportError:
     import unittest
 import imp
+import os
+import shutil
+import tempfile
+import time
 
 
 # NOTE(toabctl): Hack to import non-module file for testing
@@ -119,6 +123,31 @@ class UpdateRequiresCompleteTest(unittest.TestCase):
                              {"python-foo": ("5.0", "initsrc")},
                              {"python-foo": "2.0"}, "mysrc"))
 
+
+class TarballFinderTest(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(
+            prefix='obs-service-python_requires-test-')
+        os.chdir(self._tmpdir)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir)
+
+    def test_get_tarball_candidate_1(self):
+        print(self._tmpdir)
+        open('oslo.db-2.0.0.tar.gz', 'a').close()
+        time.sleep(0.01)
+        open('oslo.db-1.12.0.tar.gz', 'a').close()
+        self.assertEqual(pr.get_tarball_candidate(),
+                         'oslo.db-1.12.0.tar.gz')
+
+    def test_get_tarball_candidate_2(self):
+        print(self._tmpdir)
+        open('oslo.db-1.12.0.tar.gz', 'a').close()
+        time.sleep(0.01)
+        open('oslo.db-2.0.0.tar.gz', 'a').close()
+        self.assertEqual(pr.get_tarball_candidate(),
+                         'oslo.db-2.0.0.tar.gz')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For requirements detection, use the last modified tarball. Otherwise
you may use the wrong one.