### PR TITLE
Set run_requires_source in case the requirement file is missing

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -224,6 +224,7 @@ if __name__ == '__main__':
             run_requires_source = f
         except Exception:
             run_requires = ""
+            run_requires_source = ""
         else:
             break
 


### PR DESCRIPTION
In case we hit the exception we need to set also run_requires_source.