### PR TITLE
Unicode

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -102,23 +102,15 @@ def parse_update_spec_file(specfile, contents, all_requires):
     return contents
 
 
-def get_contents(fhandle):
-    return fhandle.read().decode('utf-8')
-
-
-def set_contents(fhandle, contents):
-    fhandle.write(contents.encode('utf-8'))
-
-
 def update_spec_files(all_requires):
     for specfile in glob.glob('./*.spec'):
         try:
             f = open(specfile, 'r+')
-            contents = get_contents(f)
+            contents = f.read()
             f.seek(0)
             f.truncate()
             contents = parse_update_spec_file(specfile, contents, all_requires)
-            set_contents(f, contents)
+            f.write(contents)
         finally:
             f.close()
 

--- a/python_requires
+++ b/python_requires
@@ -78,7 +78,7 @@ def parse_update_spec_file(specfile, contents, all_requires):
         contents = re.sub(
             r'^(Requires(?:\(.*\))?:[ \t]+)(%s)(?:[ \t].*)?$' % (d),
             r'\g<1>\g<2>%s' %
-            (" >= " + complete_requires[d][0] if complete_requires[d][0]
+            (" >= " + str(complete_requires[d][0]) if complete_requires[d][0]
              else ""),
             contents, flags=re.MULTILINE | re.IGNORECASE)[:]
 

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # Copyright 2015 SUSE Linux GmbH
 #
@@ -18,10 +17,8 @@
 # py26 compat
 try:
     import unittest2 as unittest
-    from StringIO import StringIO as InMemFile
 except ImportError:
     import unittest
-    from io import BytesIO as InMemFile
 import imp
 import os
 import shutil
@@ -254,37 +251,6 @@ class BaseTests(unittest.TestCase):
         # requirement (from metaextract's 'data' key)
         reqs = self._get_metaextract_fixture_2()
         self.assertDictEqual(pr._get_complete_requires(reqs), {})
-
-
-class TestContentSetterGetter(unittest.TestCase):
-
-    def test_set_contents_ascii(self):
-        f = InMemFile()
-
-        pr.set_contents(f, 'hello')
-
-        self.assertEquals(b'hello', f.getvalue())
-
-    def test_get_contents_ascii(self):
-        f = InMemFile(b'hello')
-
-        data = pr.get_contents(f)
-
-        self.assertEquals('hello', data)
-
-    def test_set_contents_utf8(self):
-        f = InMemFile()
-
-        pr.set_contents(f, u'ű')
-
-        self.assertEquals(u'ű', f.getvalue().decode('utf-8'))
-
-    def test_get_contents_utf8(self):
-        f = InMemFile(u'ű'.encode('utf-8'))
-
-        data = pr.get_contents(f)
-
-        self.assertEquals(u'ű', data)
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -194,6 +194,26 @@ class UpdateSpecFileTest(unittest.TestCase):
             )
         )
 
+    def test_parse_update_spec_file_utf8(self):
+        """No UnicodeDecodeError exception when we mix `unicode` and `str`"""
+        content_init = "\n".join([
+            "Requires: python-pkg1 >=1.0",
+            "BuildRequires: python-pkg1 >= 1.0",
+            "Description: Conversor from £ to ¥",
+        ])
+
+        try:
+            pr.parse_update_spec_file(
+                "testpackage.spec",
+                content_init, {
+                    u"install_requires": [
+                        u"pkg1>=2.0",
+                    ],
+                }
+            )
+        except UnicodeDecodeError:
+            self.fail('parse_update_spec_file() generates UnicodeDecodeError.')
+
 
 class BaseTests(unittest.TestCase):
     def _get_metaextract_fixture_1(self):


### PR DESCRIPTION
Alternative proposal to fix the UnicodeDecodeError exception, that happens when the spec file contains valid UTF-8 characters.

The problem is that `all_requires` contains a mix of Unicode and Str types. In Python 3 both data types are the same (str) but in Python 2 are different. The `re.sub()` command needs to coerce, and looks like that promote to unicode during the operation, and go back to str in the return (but in this case the encoding is ASCII)

The solution is to use only Str type during the `re.sub()`
