### PR TITLE
Handle unwanted versions better

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -21,6 +21,8 @@ import re
 
 from metaextract import utils as meta_utils
 from packaging.requirements import Requirement
+from packaging.specifiers import Specifier
+from packaging.version import Version
 
 
 def _get_complete_requires(all_requires):
@@ -157,17 +159,38 @@ def sanitize_requirements(requirements):
         version_dep = None
 
         if r.specifier:
+            # a list with unwanted sources
+            not_wanted = []
             # we want the lowest possible version
             # NOTE(toabctl): "min(r.specifier)" doesn't work.
             lowest = None
             for s in r.specifier:
                 # we don't want a lowest version which is not allowed
                 if s.operator == '!=':
+                    not_wanted.append(s)
                     continue
                 if not lowest or s.version < lowest.version:
                     lowest = s
 
             if lowest:
+                # check that our minor version is higher than all unwanted
+                # versions if the major version is equal
+                for nw in sorted(not_wanted,
+                                 key=lambda x: Version(x.version)):
+                    # only if everything except the last char is equal and a
+                    # not wanted requirement is > than the current one
+                    if Version(nw.version) > Version(lowest.version) and \
+                       nw.version.rsplit('.', 1)[0] == \
+                       lowest.version.rsplit('.', 1)[0]:
+                        try:
+                            v = nw.version.rsplit('.', 1)[0]
+                            v_minor = int(nw.version.rsplit('.', 1)[1])
+                            v_minor = v_minor + 1
+                            nw_increased = Specifier('>= %s.%s' % (v, v_minor))
+                        except:
+                            pass
+                        else:
+                            lowest = nw_increased
                 version_dep = lowest.version
 
         d["python-%s" % (pkg_name)] = version_dep

--- a/tests.py
+++ b/tests.py
@@ -85,6 +85,21 @@ class SanitizeRequirementsTests(unittest.TestCase):
                          pr.sanitize_requirements(
                              ["xyz>=1,>=2", "foo>=4,>=3.1"]))
 
+    def test_invalid_minor_version(self):
+        """select lowest but higher than invalid minor versions"""
+        self.assertEqual({"python-pecan": "1.0.5"},
+                         pr.sanitize_requirements(
+                             ["pecan!=1.0.2,!=1.0.3,!=1.0.4,>=1.0.0"]))
+        self.assertEqual({"python-pecan": "1.0.21"},
+                         pr.sanitize_requirements(
+                             ["pecan!=1.0.2,!=1.0.3,!=1.0.20,>=1.0.0"]))
+
+    def test_invalid_minor_version_with_higher_major(self):
+        """select lowest but higher than invalid minor versions"""
+        self.assertEqual({"python-pecan": "1.0.5"},
+                         pr.sanitize_requirements(
+                             ["pecan!=1.0.2,!=1.0.3,!=1.0.4,>=1.0.0,>=2.0.0"]))
+
     def test_ignore_list(self):
         self.assertEqual({},
                          pr.sanitize_requirements(


### PR DESCRIPTION
When a version is ok (eg 1.0.0) but minor newer versions are
not ok (eg != 1.0.1), try to get the next minor version and use
that as lower bound.