### PR TITLE
Do not use versions that are explicit lower

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -162,7 +162,7 @@ def sanitize_requirements(requirements):
             lowest = None
             for s in r.specifier:
                 # we don't want a lowest version which is not allowed
-                if s.operator == '!=':
+                if s.operator == '!=' or s.operator == '<':
                     continue
                 if not lowest or s.version < lowest.version:
                     lowest = s

--- a/tests.py
+++ b/tests.py
@@ -53,6 +53,10 @@ class SanitizeRequirementsTests(unittest.TestCase):
         self.assertEqual({"python-xyz": "1.2.3"},
                          pr.sanitize_requirements(["xyz >= 1.2.3"]))
 
+    def test_single_with_only_lower_version(self):
+        self.assertEqual({"python-lz4": None},
+                         pr.sanitize_requirements(["lz4<0.9.0"]))
+
     def test_multiple_with_version(self):
         self.assertEqual({"python-xyz": "1",
                           "python-foo": "3.1"},


### PR DESCRIPTION
During the search for the lowest possible version, ignore versions that are '<'.
Otherwise, for eg. 'lz4<0.9.0' we endup after the conversion with
'python-lz4>=0.9.0' which is totally wrong.