### PR TITLE
Fix pre release handling

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -20,6 +20,7 @@ import os
 import re
 
 from metaextract import utils as meta_utils
+from packaging.version import parse
 from packaging.requirements import Requirement
 
 
@@ -169,6 +170,20 @@ def sanitize_requirements(requirements):
 
             if lowest:
                 version_dep = lowest.version
+
+        # handle pre-release deps
+        if version_dep:
+            version_dep_python = parse(version_dep)
+            if version_dep_python.is_prerelease:
+                version_dep_rpm = version_dep_python.public
+                # we need to add the 'x' in front of alpha/beta release because
+                # in the python world, "1.1a10" > "1.1.dev10"
+                # but in the rpm world, "1.1~a10" < "1.1~dev10"
+                version_dep_rpm = version_dep_rpm.replace('a', '~xalpha')
+                version_dep_rpm = version_dep_rpm.replace('b', '~xbeta')
+                version_dep_rpm = version_dep_rpm.replace('rc', '~rc')
+                version_dep_rpm = version_dep_rpm.replace('.dev', '~dev')
+                version_dep = version_dep_rpm
 
         d["python-%s" % (pkg_name)] = version_dep
 

--- a/tests.py
+++ b/tests.py
@@ -52,6 +52,8 @@ class SanitizeRequirementsTests(unittest.TestCase):
                          pr.sanitize_requirements(["xyz>=1"]))
         self.assertEqual({"python-xyz": "1.2.3"},
                          pr.sanitize_requirements(["xyz >= 1.2.3"]))
+        self.assertEqual({"python-xyz": "1.2.3~xbeta1"},
+                         pr.sanitize_requirements(["xyz >= 1.2.3b1"]))
 
     def test_single_with_only_lower_version(self):
         self.assertEqual({"python-lz4": None},


### PR DESCRIPTION
pre releases in python (like kubernetes-1.0.0rc1) need special
handling when the version is converted to an RPM version because in
the RPM world, 1.0.0rc1 is greater than 1.0.0 but the same is not true
for pip.
So use the '~' to handle pre-releases.