### PR TITLE
Fix rc version handling for pip-to-rpm convertion

### DIFF
--- a/python_requires
+++ b/python_requires
@@ -181,7 +181,7 @@ def sanitize_requirements(requirements):
                 # but in the rpm world, "1.1~a10" < "1.1~dev10"
                 version_dep_rpm = version_dep_rpm.replace('a', '~xalpha')
                 version_dep_rpm = version_dep_rpm.replace('b', '~xbeta')
-                version_dep_rpm = version_dep_rpm.replace('rc', '~rc')
+                version_dep_rpm = version_dep_rpm.replace('rc', '~xrc')
                 version_dep_rpm = version_dep_rpm.replace('.dev', '~dev')
                 version_dep = version_dep_rpm
 


### PR DESCRIPTION
There needs to be an "x" in front of the converted rc
version. Otherwise eg. "1.1~rc9 > 1.1~xbeta10" is not true in the RPM
world.